### PR TITLE
Update matchMedia.js

### DIFF
--- a/matchMedia.js
+++ b/matchMedia.js
@@ -60,8 +60,8 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
     if( mqSupport ) {
       return mqRun( mq );
     } else {
-      var min = mq.match( /\(min\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ),
-          max = mq.match( /\(max\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ),
+      var min = mq.match( /\(min\-width[\s]*:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ),
+          max = mq.match( /\(max\-width[\s]*:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ),
           minnull = min === null,
           maxnull = max === null,
           currWidth = doc.body.offsetWidth,


### PR DESCRIPTION
Updated regex to support whitespaces between min-width and :

Previous code was not working when there was a space in between min-width/max-width and colon.
